### PR TITLE
Add ENTSO-E day-ahead price widget for WordPress

### DIFF
--- a/Python/EntsoeDayAheadWidget/.gitignore
+++ b/Python/EntsoeDayAheadWidget/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+.venv/

--- a/Python/EntsoeDayAheadWidget/README.md
+++ b/Python/EntsoeDayAheadWidget/README.md
@@ -1,0 +1,113 @@
+# ENTSO-E Day-Ahead Prijzen Widget voor WordPress
+
+Een kleine Python-webapp (Flask) die de **dagelijkse uurprijzen elektriciteit**
+van de ENTSO-E day-ahead veiling ophaalt en als interactieve grafiek
+(Chart.js) toont. De grafiek is eenvoudig te integreren in een
+WordPress-website via een iframe of de meegeleverde shortcode-plugin.
+
+> WordPress zelf draait PHP en kan geen Python uitvoeren. Daarom draait de
+> Python-app als kleine webservice (op je eigen server, VPS of een gratis
+> hosting zoals Render/Railway/PythonAnywhere) en embed je de grafiek in
+> WordPress.
+
+## Functies
+
+- Uurprijzen van vandaag (of een andere dag via `?date=YYYY-MM-DD`)
+- Biedzones: NL, BE, DE, FR (eenvoudig uit te breiden in `BIDDING_ZONES`)
+- Kwartierprijzen (15-minuten-MTU) worden automatisch gemiddeld naar uurprijzen
+- Staafgrafiek met kleurcodering goedkoop/gemiddeld/duur, huidig uur gemarkeerd
+- Min/gemiddeld/max van de dag, prijzen in ct/kWh én €/MWh
+- JSON-API op `/api/prices` voor eigen toepassingen
+- Caching (15 min) zodat de ENTSO-E API niet onnodig wordt belast
+
+## 1. ENTSO-E API-token aanvragen (gratis)
+
+1. Maak een account aan op <https://transparency.entsoe.eu>
+2. Vraag Web API-toegang aan: stuur een e-mail naar
+   `transparency@entsoe.eu` met onderwerp "Restful API access" en het
+   e-mailadres van je account
+3. Na bevestiging vind je het token onder *My Account Settings → Web API
+   Security Token*
+
+## 2. Lokaal draaien
+
+```bash
+cd Python/EntsoeDayAheadWidget
+python -m venv .venv && source .venv/bin/activate
+pip install -r requirements.txt
+
+export ENTSOE_API_TOKEN="jouw-token-hier"
+python app.py
+```
+
+Open daarna:
+
+- Widget:   <http://localhost:8000/widget?zone=NL>
+- JSON-API: <http://localhost:8000/api/prices?zone=NL>
+
+## 3. Productie (server/VPS)
+
+```bash
+export ENTSOE_API_TOKEN="jouw-token-hier"
+gunicorn -w 2 -b 0.0.0.0:8000 app:app
+```
+
+Zet er bij voorkeur een reverse proxy met HTTPS voor (nginx/Caddy), zodat de
+widget bereikbaar is op bv. `https://prijzen.jouwdomein.nl/widget`.
+HTTPS is verplicht als je WordPress-site ook HTTPS gebruikt (mixed content
+wordt anders geblokkeerd door de browser).
+
+## 4. Integreren in WordPress
+
+### Optie A – HTML-blok (snelste manier)
+
+Voeg in de Gutenberg-editor een **Aangepaste HTML**-blok toe met:
+
+```html
+<iframe src="https://prijzen.jouwdomein.nl/widget?zone=NL"
+        style="width:100%;border:0;" height="430" loading="lazy"
+        title="Day-ahead elektriciteitsprijzen"></iframe>
+```
+
+### Optie B – Shortcode-plugin
+
+1. Kopieer `wordpress/entsoe-prijzen-widget.php` naar
+   `wp-content/plugins/` van je WordPress-installatie
+2. Pas de constante `ENTSOE_WIDGET_URL` aan naar jouw widget-URL
+   (in het bestand zelf, of via `define('ENTSOE_WIDGET_URL', '...');`
+   in `wp-config.php`)
+3. Activeer de plugin in het WordPress-dashboard
+4. Gebruik in een pagina of bericht:
+
+```
+[entsoe_prijzen]
+[entsoe_prijzen zone="BE" hoogte="450"]
+```
+
+## API-referentie
+
+`GET /api/prices?zone=NL&date=2026-06-10`
+
+```json
+{
+  "zone": "NL",
+  "zone_label": "Nederland",
+  "date": "2026-06-10",
+  "unit": "EUR/MWh",
+  "source": "ENTSO-E Transparency Platform (day-ahead veiling)",
+  "prices": [
+    {"time": "2026-06-10T00:00:00+02:00", "hour": "00:00",
+     "price_eur_mwh": 85.2, "price_ct_kwh": 8.52}
+  ]
+}
+```
+
+`GET /widget?zone=NL[&date=YYYY-MM-DD]` – de embeddebare grafiekpagina.
+
+## Opmerkingen
+
+- De prijzen voor **morgen** worden door ENTSO-E gepubliceerd rond
+  13:00–14:00 CET; gebruik dan `?date=` met de datum van morgen.
+- De getoonde prijzen zijn kale groothandelsprijzen (day-ahead) en zijn dus
+  **exclusief** energiebelasting, btw en de inkoopvergoeding van je
+  leverancier.

--- a/Python/EntsoeDayAheadWidget/app.py
+++ b/Python/EntsoeDayAheadWidget/app.py
@@ -1,0 +1,249 @@
+"""
+ENTSO-E Day-Ahead prijzen widget.
+
+Een kleine Flask-applicatie die de dagelijkse uurprijzen elektriciteit
+(day-ahead veiling) ophaalt van het ENTSO-E Transparency Platform en
+serveert als:
+
+  * /api/prices  -> JSON met uurprijzen (EUR/MWh en ct/kWh)
+  * /widget      -> kant-en-klare HTML-pagina met grafiek (Chart.js),
+                    te embedden in WordPress via een iframe of shortcode.
+
+Vereist een (gratis) API-token van het ENTSO-E Transparency Platform,
+aan te leveren via de omgevingsvariabele ENTSOE_API_TOKEN.
+Zie README.md voor installatie- en WordPress-instructies.
+"""
+
+import os
+import threading
+import xml.etree.ElementTree as ET
+from datetime import datetime, timedelta, timezone
+from zoneinfo import ZoneInfo
+
+import requests
+from flask import Flask, jsonify, render_template, request
+
+app = Flask(__name__)
+
+ENTSOE_API_URL = "https://web-api.tp.entsoe.eu/api"
+ENTSOE_API_TOKEN = os.environ.get("ENTSOE_API_TOKEN", "")
+
+LOCAL_TZ = ZoneInfo("Europe/Amsterdam")
+
+# EIC-codes van enkele biedzones. Uit te breiden naar behoefte:
+# https://www.entsoe.eu/data/energy-identification-codes-eic/
+BIDDING_ZONES = {
+    "NL": ("10YNL----------L", "Nederland"),
+    "BE": ("10YBE----------2", "België"),
+    "DE": ("10Y1001A1001A82H", "Duitsland-Luxemburg"),
+    "FR": ("10YFR-RTE------C", "Frankrijk"),
+}
+
+CACHE_TTL = timedelta(minutes=15)
+_cache = {}
+_cache_lock = threading.Lock()
+
+
+def _strip_ns(tag):
+    """Verwijder de XML-namespace van een tag, bv. '{ns}Point' -> 'Point'."""
+    return tag.rsplit("}", 1)[-1]
+
+
+def _iter_children(element, name):
+    for child in element:
+        if _strip_ns(child.tag) == name:
+            yield child
+
+
+def _find_text(element, *path):
+    """Zoek namespace-onafhankelijk een geneste tekstwaarde."""
+    current = element
+    for name in path:
+        current = next(_iter_children(current, name), None)
+        if current is None:
+            return None
+    return (current.text or "").strip()
+
+
+def _resolution_minutes(resolution):
+    return {"PT15M": 15, "PT30M": 30, "PT60M": 60, "P1D": 1440}.get(resolution)
+
+
+def _parse_document(xml_text):
+    """
+    Parseer een Publication_MarketDocument naar een dict
+    {utc_datetime: prijs_eur_mwh} op de resolutie van het document.
+
+    Houdt rekening met curve type A03: ontbrekende posities betekenen
+    'zelfde prijs als vorige punt' en worden vooruit gevuld.
+    """
+    root = ET.fromstring(xml_text)
+    if _strip_ns(root.tag) == "Acknowledgement_MarketDocument":
+        reason = _find_text(root, "Reason", "text") or "Geen data beschikbaar"
+        raise LookupError(reason)
+
+    prices = {}
+    for series in _iter_children(root, "TimeSeries"):
+        for period in _iter_children(series, "Period"):
+            start_text = _find_text(period, "timeInterval", "start")
+            end_text = _find_text(period, "timeInterval", "end")
+            resolution = _find_text(period, "resolution")
+            minutes = _resolution_minutes(resolution)
+            if not (start_text and end_text and minutes):
+                continue
+
+            start = datetime.fromisoformat(start_text.replace("Z", "+00:00"))
+            end = datetime.fromisoformat(end_text.replace("Z", "+00:00"))
+            total_points = int((end - start) / timedelta(minutes=minutes))
+
+            by_position = {}
+            for point in _iter_children(period, "Point"):
+                position = _find_text(point, "position")
+                amount = _find_text(point, "price.amount")
+                if position and amount:
+                    by_position[int(position)] = float(amount)
+
+            last_price = None
+            for position in range(1, total_points + 1):
+                last_price = by_position.get(position, last_price)
+                if last_price is None:
+                    continue
+                moment = start + timedelta(minutes=minutes * (position - 1))
+                prices[moment] = (last_price, minutes)
+    return prices
+
+
+def _to_hourly(prices):
+    """
+    Aggregeer naar uurprijzen. Sinds de overgang van de day-ahead markt
+    naar 15-minuten-MTU levert ENTSO-E kwartierwaarden; het gemiddelde
+    per uur komt overeen met de uurprijs zoals leveranciers die tonen.
+    """
+    buckets = {}
+    for moment, (price, _minutes) in prices.items():
+        hour = moment.replace(minute=0, second=0, microsecond=0)
+        buckets.setdefault(hour, []).append(price)
+    return {hour: sum(values) / len(values) for hour, values in buckets.items()}
+
+
+def fetch_day_ahead_prices(zone_code, day):
+    """
+    Haal de day-ahead uurprijzen op voor 'day' (een date in lokale tijd)
+    en geef een gesorteerde lijst dicts terug.
+    """
+    if not ENTSOE_API_TOKEN:
+        raise RuntimeError(
+            "Geen ENTSOE_API_TOKEN gezet. Vraag een gratis Web API token aan "
+            "op https://transparency.entsoe.eu en zet de omgevingsvariabele."
+        )
+
+    eic, _label = BIDDING_ZONES[zone_code]
+    local_start = datetime.combine(day, datetime.min.time(), tzinfo=LOCAL_TZ)
+    local_end = local_start + timedelta(days=1)
+    fmt = "%Y%m%d%H%M"
+
+    response = requests.get(
+        ENTSOE_API_URL,
+        params={
+            "securityToken": ENTSOE_API_TOKEN,
+            "documentType": "A44",  # Price Document (day-ahead prijzen)
+            "in_Domain": eic,
+            "out_Domain": eic,
+            "periodStart": local_start.astimezone(timezone.utc).strftime(fmt),
+            "periodEnd": local_end.astimezone(timezone.utc).strftime(fmt),
+        },
+        timeout=30,
+    )
+    response.raise_for_status()
+
+    hourly = _to_hourly(_parse_document(response.text))
+    rows = []
+    for hour_utc in sorted(hourly):
+        hour_local = hour_utc.astimezone(LOCAL_TZ)
+        if not local_start <= hour_local < local_end:
+            continue
+        price = round(hourly[hour_utc], 2)
+        rows.append(
+            {
+                "time": hour_local.isoformat(),
+                "hour": hour_local.strftime("%H:%M"),
+                "price_eur_mwh": price,
+                "price_ct_kwh": round(price / 10.0, 2),
+            }
+        )
+    if not rows:
+        raise LookupError("Geen prijzen gevonden voor deze dag.")
+    return rows
+
+
+def get_prices_cached(zone_code, day):
+    key = (zone_code, day)
+    now = datetime.now(timezone.utc)
+    with _cache_lock:
+        cached = _cache.get(key)
+        if cached and now - cached[0] < CACHE_TTL:
+            return cached[1]
+    rows = fetch_day_ahead_prices(zone_code, day)
+    with _cache_lock:
+        _cache[key] = (now, rows)
+    return rows
+
+
+def _request_zone_and_day():
+    zone = request.args.get("zone", "NL").upper()
+    if zone not in BIDDING_ZONES:
+        raise LookupError(f"Onbekende zone '{zone}'. Kies uit: {', '.join(BIDDING_ZONES)}")
+    date_arg = request.args.get("date")
+    day = (
+        datetime.strptime(date_arg, "%Y-%m-%d").date()
+        if date_arg
+        else datetime.now(LOCAL_TZ).date()
+    )
+    return zone, day
+
+
+@app.after_request
+def allow_embedding(response):
+    # Nodig zodat WordPress (ander domein) het widget mag embedden/fetchen.
+    response.headers["Access-Control-Allow-Origin"] = "*"
+    response.headers["Content-Security-Policy"] = "frame-ancestors *"
+    return response
+
+
+@app.route("/api/prices")
+def api_prices():
+    try:
+        zone, day = _request_zone_and_day()
+        rows = get_prices_cached(zone, day)
+    except LookupError as exc:
+        return jsonify({"error": str(exc)}), 404
+    except (requests.RequestException, RuntimeError) as exc:
+        return jsonify({"error": str(exc)}), 502
+    return jsonify(
+        {
+            "zone": zone,
+            "zone_label": BIDDING_ZONES[zone][1],
+            "date": day.isoformat(),
+            "currency": "EUR",
+            "unit": "EUR/MWh",
+            "source": "ENTSO-E Transparency Platform (day-ahead veiling)",
+            "prices": rows,
+        }
+    )
+
+
+@app.route("/widget")
+def widget():
+    zone = request.args.get("zone", "NL").upper()
+    if zone not in BIDDING_ZONES:
+        zone = "NL"
+    return render_template("widget.html", zone=zone, zone_label=BIDDING_ZONES[zone][1])
+
+
+@app.route("/")
+def index():
+    return widget()
+
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=int(os.environ.get("PORT", 8000)))

--- a/Python/EntsoeDayAheadWidget/requirements.txt
+++ b/Python/EntsoeDayAheadWidget/requirements.txt
@@ -1,0 +1,3 @@
+flask>=3.0
+requests>=2.31
+gunicorn>=21.2

--- a/Python/EntsoeDayAheadWidget/templates/widget.html
+++ b/Python/EntsoeDayAheadWidget/templates/widget.html
@@ -1,0 +1,150 @@
+<!DOCTYPE html>
+<html lang="nl">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Day-ahead elektriciteitsprijzen – {{ zone_label }}</title>
+<script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.7/dist/chart.umd.min.js"></script>
+<style>
+  :root {
+    --fg: #1f2937;
+    --muted: #6b7280;
+    --bg: #ffffff;
+  }
+  body {
+    margin: 0;
+    padding: 12px;
+    background: var(--bg);
+    color: var(--fg);
+    font-family: -apple-system, "Segoe UI", Roboto, Arial, sans-serif;
+  }
+  .header {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    flex-wrap: wrap;
+    gap: 4px 12px;
+    margin-bottom: 8px;
+  }
+  h1 { font-size: 1rem; margin: 0; }
+  .sub { font-size: 0.8rem; color: var(--muted); }
+  .stats {
+    display: flex;
+    gap: 16px;
+    font-size: 0.8rem;
+    color: var(--muted);
+    margin-bottom: 8px;
+    flex-wrap: wrap;
+  }
+  .stats b { color: var(--fg); }
+  .chart-wrap { position: relative; height: 300px; }
+  #message { font-size: 0.9rem; color: #b91c1c; padding: 16px 0; }
+  .footer { font-size: 0.7rem; color: var(--muted); margin-top: 8px; }
+</style>
+</head>
+<body>
+  <div class="header">
+    <h1>Stroomprijzen vandaag – {{ zone_label }}</h1>
+    <span class="sub" id="dateLabel"></span>
+  </div>
+  <div class="stats" id="stats" hidden>
+    <span>Min: <b id="statMin"></b></span>
+    <span>Gemiddeld: <b id="statAvg"></b></span>
+    <span>Max: <b id="statMax"></b></span>
+  </div>
+  <div class="chart-wrap"><canvas id="priceChart"></canvas></div>
+  <div id="message" hidden></div>
+  <div class="footer">Bron: ENTSO-E Transparency Platform (day-ahead veiling), prijzen in ct/kWh excl. belastingen en inkoopkosten.</div>
+
+<script>
+(async function () {
+  const params = new URLSearchParams(location.search);
+  const zone = params.get("zone") || "{{ zone }}";
+  const date = params.get("date");
+
+  const apiUrl = new URL("api/prices", location.href.replace(/widget.*$/, ""));
+  apiUrl.searchParams.set("zone", zone);
+  if (date) apiUrl.searchParams.set("date", date);
+
+  const messageEl = document.getElementById("message");
+  let data;
+  try {
+    const response = await fetch(apiUrl);
+    data = await response.json();
+    if (!response.ok) throw new Error(data.error || response.statusText);
+  } catch (err) {
+    messageEl.textContent = "Prijzen konden niet worden geladen: " + err.message;
+    messageEl.hidden = false;
+    return;
+  }
+
+  document.getElementById("dateLabel").textContent =
+    new Date(data.date + "T00:00:00").toLocaleDateString("nl-NL",
+      { weekday: "long", day: "numeric", month: "long", year: "numeric" });
+
+  const prices = data.prices.map(p => p.price_ct_kwh);
+  const labels = data.prices.map(p => p.hour);
+  const min = Math.min(...prices), max = Math.max(...prices);
+  const avg = prices.reduce((a, b) => a + b, 0) / prices.length;
+  const fmt = v => v.toFixed(1).replace(".", ",") + " ct/kWh";
+  document.getElementById("statMin").textContent = fmt(min);
+  document.getElementById("statAvg").textContent = fmt(avg);
+  document.getElementById("statMax").textContent = fmt(max);
+  document.getElementById("stats").hidden = false;
+
+  // Kleur per staaf: groen (goedkoop) -> oranje -> rood (duur), relatief
+  // t.o.v. de spreiding van vandaag. Huidig uur krijgt een blauwe rand.
+  const nowHour = new Date().toLocaleString("sv-SE",
+    { timeZone: "Europe/Amsterdam", hour12: false }).slice(0, 13);
+  const colors = data.prices.map(p => {
+    const t = max === min ? 0.5 : (p.price_ct_kwh - min) / (max - min);
+    if (t < 0.33) return "rgba(34,197,94,0.75)";
+    if (t < 0.66) return "rgba(245,158,11,0.75)";
+    return "rgba(239,68,68,0.75)";
+  });
+  const borders = data.prices.map(p =>
+    p.time.slice(0, 13) === nowHour ? "rgba(37,99,235,1)" : "rgba(0,0,0,0)");
+
+  new Chart(document.getElementById("priceChart"), {
+    type: "bar",
+    data: {
+      labels: labels,
+      datasets: [{
+        data: prices,
+        backgroundColor: colors,
+        borderColor: borders,
+        borderWidth: 2,
+      }],
+    },
+    options: {
+      responsive: true,
+      maintainAspectRatio: false,
+      plugins: {
+        legend: { display: false },
+        tooltip: {
+          callbacks: {
+            title: items => items[0].label + " uur",
+            label: ctx => {
+              const p = data.prices[ctx.dataIndex];
+              return fmt(p.price_ct_kwh) + "  (" +
+                p.price_eur_mwh.toFixed(2).replace(".", ",") + " €/MWh)";
+            },
+          },
+        },
+      },
+      scales: {
+        y: {
+          title: { display: true, text: "ct/kWh" },
+          grid: { color: "rgba(0,0,0,0.06)" },
+        },
+        x: {
+          ticks: { maxRotation: 0, autoSkipPadding: 8 },
+          grid: { display: false },
+        },
+      },
+    },
+  });
+})();
+</script>
+</body>
+</html>

--- a/Python/EntsoeDayAheadWidget/wordpress/entsoe-prijzen-widget.php
+++ b/Python/EntsoeDayAheadWidget/wordpress/entsoe-prijzen-widget.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Plugin Name: ENTSO-E Prijzen Widget
+ * Description: Toont de dagelijkse day-ahead uurprijzen elektriciteit (ENTSO-E) als grafiek via een shortcode: [entsoe_prijzen]
+ * Version: 1.0.0
+ * Author: -
+ *
+ * Gebruik in een bericht of pagina:
+ *   [entsoe_prijzen]
+ *   [entsoe_prijzen zone="BE" hoogte="450"]
+ *
+ * Stel hieronder (of via de constante in wp-config.php) de URL in van de
+ * draaiende Python-widget, bv. https://prijzen.jouwdomein.nl/widget
+ */
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+if (!defined('ENTSOE_WIDGET_URL')) {
+    define('ENTSOE_WIDGET_URL', 'https://prijzen.jouwdomein.nl/widget');
+}
+
+function entsoe_prijzen_shortcode($atts)
+{
+    $atts = shortcode_atts(
+        array(
+            'zone'   => 'NL',
+            'hoogte' => '430',
+            'url'    => ENTSOE_WIDGET_URL,
+        ),
+        $atts,
+        'entsoe_prijzen'
+    );
+
+    $src = add_query_arg(
+        array('zone' => strtoupper(sanitize_text_field($atts['zone']))),
+        esc_url_raw($atts['url'])
+    );
+
+    return sprintf(
+        '<iframe src="%s" style="width:100%%;border:0;" height="%d" loading="lazy" title="Day-ahead elektriciteitsprijzen"></iframe>',
+        esc_url($src),
+        (int) $atts['hoogte']
+    );
+}
+add_shortcode('entsoe_prijzen', 'entsoe_prijzen_shortcode');


### PR DESCRIPTION
Flask app that fetches daily hourly electricity prices from the ENTSO-E Transparency Platform (day-ahead auction) and serves them as a JSON API plus an embeddable Chart.js bar chart. Includes a WordPress shortcode plugin and Dutch setup instructions. Handles 15-minute MTU data by averaging to hourly prices and caches API responses.

https://claude.ai/code/session_01UZ5PLxy4F2sjtvi2BKSSvu